### PR TITLE
feat: add support for setting `folder` on `getCommits`

### DIFF
--- a/src/commits.ts
+++ b/src/commits.ts
@@ -2,16 +2,48 @@ import type { GitCommit } from "./types";
 import { getRawGitCommitStrings } from "./git";
 import { parseCommit, parseRawCommit } from "./parse";
 
+export interface GetCommitsOptions {
+  /**
+   * The starting reference (commit, branch, tag). If undefined, it will fetch commits up to the `to` reference.
+   * @default undefined
+   */
+  from?: string;
+
+  /**
+   * The ending reference. Defaults to "HEAD".
+   * @default "HEAD"
+   */
+  to?: string;
+
+  /**
+   * The current working directory where the git command will be executed.
+   * If not provided, the command will run in the process's current directory.
+   * @default process.cwd()
+   */
+  cwd?: string;
+
+  /**
+   * The folder to provide to the git command.
+   * This is useful when you only want to retrieve commits from a specific folder.
+   * @default undefined
+   */
+  folder?: string;
+}
+
 /**
  * Retrieves a list of parsed git commits between two points in history.
  *
- * @param {string?} from - The starting point in git history. If omitted, will use the default git behavior.
- * @param {string?} to - The ending point in git history. If omitted, will use the default git behavior.
- * @param {string?} cwd - The current working directory in which to execute the git command. Defaults to process.cwd().
+ * @param {GetCommitsOptions} options - Options for fetching and parsing git commits.
+ *
  * @returns {GitCommit[]} An array of parsed GitCommit objects.
  */
-export function getCommits(from?: string, to?: string, cwd?: string): GitCommit[] {
-  return getRawGitCommitStrings(from, to, cwd)
+export function getCommits(options: GetCommitsOptions): GitCommit[] {
+  return getRawGitCommitStrings({
+    from: options.from,
+    to: options.to,
+    cwd: options.cwd,
+    folder: options.folder,
+  })
     .map(parseRawCommit)
     .map(parseCommit);
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -22,16 +22,51 @@ function execCommand(cmd: string, cwd?: string): string {
  */
 const GIT_LOG_FORMAT = "----%n%h|%s|%an|%ae|%ad|%b";
 
+export interface GetRawGitCommitStringsOptions {
+  /**
+   * The starting reference (commit, branch, tag). If undefined, it will fetch commits up to the `to` reference.
+   * @default undefined
+   */
+  from?: string;
+
+  /**
+   * The ending reference. Defaults to "HEAD".
+   * @default "HEAD"
+   */
+  to?: string;
+
+  /**
+   * The current working directory where the git command will be executed.
+   * If not provided, the command will run in the process's current directory.
+   * @default process.cwd()
+   */
+  cwd?: string;
+
+  /**
+   * The folder to provide to the git command.
+   * This is useful when you only want to retrieve commits from a specific folder.
+   * @default undefined
+   */
+  folder?: string;
+}
+
 /**
  * Retrieves raw git commits between two references.
  *
- * @param {string | undefined} from - The starting reference (commit, branch, tag). If undefined, it will fetch commits up to the `to` reference.
- * @param {string} [to] - The ending reference. Defaults to "HEAD".
- * @param {string?} cwd - The current working directory where the git command will be executed. If not provided, the command will run in the process's current directory.
+ * @param {GetRawGitCommitStringsOptions} options - Options for fetching raw git commits.
+ *
  * @returns {string[]} An array of raw git commit strings.
  */
-export function getRawGitCommitStrings(from: string | undefined, to: string = "HEAD", cwd?: string): string[] {
-  const output = execCommand(`git --no-pager log "${from ? `${from}...${to}` : to}" --pretty="${GIT_LOG_FORMAT}"`, cwd);
+export function getRawGitCommitStrings(options: GetRawGitCommitStringsOptions): string[] {
+  const {
+    from,
+    to = "HEAD",
+    cwd,
+    folder,
+  } = options;
+
+  const folderPath = folder ? ` -- ${folder}` : "";
+  const output = execCommand(`git --no-pager log "${from ? `${from}...${to}` : to}" --pretty="${GIT_LOG_FORMAT}"${folderPath}`, cwd);
   return output
     .split("----\n")
     .filter(Boolean);

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -158,4 +158,26 @@ describe("getRawGitCommitStrings", () => {
       "ghi789|Third commit|Bob Brown|bob@example.com|Mon Apr 13 2025|Third message",
     ]);
   });
+
+  it("should use the provided folder parameter", () => {
+    const sampleOutput = "----\n"
+      + "abc123|Add feature|John Doe|john@example.com|Wed Apr 15 2025|Commit message";
+
+    mockExecSync.mockReturnValue(sampleOutput);
+
+    const result = getRawGitCommitStrings({
+      from: "v1.0.0",
+      to: "HEAD",
+      folder: "src",
+    });
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      "git --no-pager log \"v1.0.0...HEAD\" --pretty=\"----%n%h|%s|%an|%ae|%ad|%b\" -- src",
+      { encoding: "utf8", cwd: undefined, stdio: ["pipe", "pipe", "pipe"] },
+    );
+
+    expect(result).toEqual([
+      "abc123|Add feature|John Doe|john@example.com|Wed Apr 15 2025|Commit message",
+    ]);
+  });
 });

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -26,7 +26,10 @@ describe("getRawGitCommitStrings", () => {
 
     mockExecSync.mockReturnValue(sampleOutput);
 
-    const result = getRawGitCommitStrings(undefined, "main");
+    const result = getRawGitCommitStrings({
+      from: undefined,
+      to: "main",
+    });
 
     expect(mockExecSync).toHaveBeenCalledWith(
       "git --no-pager log \"main\" --pretty=\"----%n%h|%s|%an|%ae|%ad|%b\"",
@@ -45,7 +48,7 @@ describe("getRawGitCommitStrings", () => {
 
     mockExecSync.mockReturnValue(sampleOutput);
 
-    const result = getRawGitCommitStrings("v1.0.0", "v2.0.0");
+    const result = getRawGitCommitStrings({ from: "v1.0.0", to: "v2.0.0" });
 
     expect(mockExecSync).toHaveBeenCalledWith(
       "git --no-pager log \"v1.0.0...v2.0.0\" --pretty=\"----%n%h|%s|%an|%ae|%ad|%b\"",
@@ -63,7 +66,9 @@ describe("getRawGitCommitStrings", () => {
 
     mockExecSync.mockReturnValue(sampleOutput);
 
-    const result = getRawGitCommitStrings("v1.0.0");
+    const result = getRawGitCommitStrings({
+      from: "v1.0.0",
+    });
 
     expect(mockExecSync).toHaveBeenCalledWith(
       "git --no-pager log \"v1.0.0...HEAD\" --pretty=\"----%n%h|%s|%an|%ae|%ad|%b\"",
@@ -85,7 +90,11 @@ describe("getRawGitCommitStrings", () => {
 
     mockExecSync.mockReturnValue(sampleOutput);
 
-    const result = getRawGitCommitStrings("v1.0.0", "HEAD", "/path/to/repo");
+    const result = getRawGitCommitStrings({
+      from: "v1.0.0",
+      to: "HEAD",
+      cwd: "/path/to/repo",
+    });
 
     expect(mockExecSync).toHaveBeenCalledWith(
       "git --no-pager log \"v1.0.0...HEAD\" --pretty=\"----%n%h|%s|%an|%ae|%ad|%b\"",
@@ -103,7 +112,7 @@ describe("getRawGitCommitStrings", () => {
 
     mockExecSync.mockReturnValue(sampleOutput);
 
-    const result = getRawGitCommitStrings(undefined, "HEAD");
+    const result = getRawGitCommitStrings({ from: undefined, to: "HEAD" });
 
     expect(result).toEqual([
       "abc123|Add feature|John Doe|john@example.com|Wed Apr 15 2025|This is commit body\nwith multiple lines\nand more text",
@@ -116,7 +125,7 @@ describe("getRawGitCommitStrings", () => {
 
     mockExecSync.mockReturnValue(sampleOutput);
 
-    const result = getRawGitCommitStrings(undefined, "HEAD");
+    const result = getRawGitCommitStrings({ from: undefined, to: "HEAD" });
 
     expect(result).toEqual([
       "abc123|Add feature|John Doe|john@example.com|Wed Apr 15 2025|This commit contains | pipe characters",
@@ -126,7 +135,7 @@ describe("getRawGitCommitStrings", () => {
   it("should handle empty result", () => {
     mockExecSync.mockReturnValue("");
 
-    const result = getRawGitCommitStrings("v1.0.0", "v2.0.0");
+    const result = getRawGitCommitStrings({ from: "v1.0.0", to: "v2.0.0" });
 
     expect(result).toEqual([]);
   });
@@ -141,7 +150,7 @@ describe("getRawGitCommitStrings", () => {
 
     mockExecSync.mockReturnValue(sampleOutput);
 
-    const result = getRawGitCommitStrings(undefined, "HEAD");
+    const result = getRawGitCommitStrings({ from: undefined, to: "HEAD" });
 
     expect(result).toEqual([
       "abc123|First commit|John Doe|john@example.com|Wed Apr 15 2025|First message\n",


### PR DESCRIPTION
This pull request refactors the `getCommits` and `getRawGitCommitStrings` functions to use unified options objects, improving clarity and extensibility. Additionally, it updates the corresponding test cases to align with the new function signatures and adds support for a new `folder` parameter.

### Refactoring and API Changes:
* Introduced `GetCommitsOptions` and `GetRawGitCommitStringsOptions` interfaces to encapsulate parameters for `getCommits` and `getRawGitCommitStrings` functions, respectively. This replaces the previous positional parameters with a single options object for better readability and flexibility. (`src/commits.ts`, `src/git.ts`) [[1]](diffhunk://#diff-3dc19cc8ab40174716d2278a8c0d8a6648c6793d28b5b5c08d479c4d4a67bb04R5-R46) [[2]](diffhunk://#diff-2ea4750851b34def3ddd617afa64e175a87064a29dbb9e6fd20eee6f1dd6dc93R25-R69)
* Added support for a `folder` parameter in `getRawGitCommitStrings`, allowing users to filter commits by a specific folder. (`src/git.ts`)

### Test Updates:
* Updated all test cases for `getRawGitCommitStrings` to use the new options object format instead of positional parameters. (`test/git.test.ts`) [[1]](diffhunk://#diff-995d4ec76c7d7008f618ff388c1d0f1dcd8b88d3e9ecbf399182ac68dbead0deL29-R32) [[2]](diffhunk://#diff-995d4ec76c7d7008f618ff388c1d0f1dcd8b88d3e9ecbf399182ac68dbead0deL48-R51) [[3]](diffhunk://#diff-995d4ec76c7d7008f618ff388c1d0f1dcd8b88d3e9ecbf399182ac68dbead0deL66-R71) [[4]](diffhunk://#diff-995d4ec76c7d7008f618ff388c1d0f1dcd8b88d3e9ecbf399182ac68dbead0deL88-R97) [[5]](diffhunk://#diff-995d4ec76c7d7008f618ff388c1d0f1dcd8b88d3e9ecbf399182ac68dbead0deL106-R115) [[6]](diffhunk://#diff-995d4ec76c7d7008f618ff388c1d0f1dcd8b88d3e9ecbf399182ac68dbead0deL119-R128) [[7]](diffhunk://#diff-995d4ec76c7d7008f618ff388c1d0f1dcd8b88d3e9ecbf399182ac68dbead0deL129-R138) [[8]](diffhunk://#diff-995d4ec76c7d7008f618ff388c1d0f1dcd8b88d3e9ecbf399182ac68dbead0deL144-R182)
* Added a new test case to verify the behavior of the `folder` parameter in `getRawGitCommitStrings`. (`test/git.test.ts`)